### PR TITLE
"Contact us tooltip" for GitHub icon showing LinkedIn instead of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Getting up and running
 
 Use latest version of Node (v10.6.0)
-Prefereably use Node Version Manager (https://github.com/creationix/nvm)
+Preferably use Node Version Manager (https://github.com/creationix/nvm)
 
 Install dev dependencies:
 ```

--- a/index.html
+++ b/index.html
@@ -760,7 +760,7 @@
                                                                                         <a target="_blank" href="https://www.instagram.com/kjsce_codecell/" class="insta" title="Join us on Instagram">
                                                                                             <i class="fa fa-instagram"></i>
                                                                                         </a>
-                                                                                        <a target="_blank" href="https://github.com/KJSCE-Codecell" class="in" title="Join us on Linked In">
+                                                                                        <a target="_blank" href="https://github.com/KJSCE-Codecell" class="in" title="Join us on GitHub">
                                                                                             <i class="fa fa-github"></i>
                                                                                         </a>
                                                                                     </div>


### PR DESCRIPTION
**Before** :
![GitHub tooltip old](https://imgur.com/oAbHKkX.png)

**After** :
![GitHub tooltip new](https://imgur.com/KbVmZVk.png)